### PR TITLE
Example of API usage to load saved subtree components

### DIFF
--- a/loading_saved_components.ipynb
+++ b/loading_saved_components.ipynb
@@ -1,0 +1,460 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "view-in-github"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/CanopySimulations/canopy-python-examples/blob/master/loading_and_saving_configs.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NtIv7oIVvn5i"
+      },
+      "source": [
+        "# Upgrade Runtime\n",
+        "This cell ensures the runtime supports `asyncio` async/await, and is needed on Google Colab. If the runtime is upgraded, you will be prompted to restart it, which you should do before continuing execution."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "E-AnefvPvmtR"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install ipython ipykernel --upgrade"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_61Bg2_KwIR2"
+      },
+      "source": [
+        "# Set Up Environment"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zX-xTWzWG1bt"
+      },
+      "source": [
+        "### Import required libraries"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gNnEvtkmwL0W"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install -q canopy"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "0bBsqDyhwN_8"
+      },
+      "outputs": [],
+      "source": [
+        "import canopy\n",
+        "import logging\n",
+        "import nest_asyncio\n",
+        "\n",
+        "logging.basicConfig(level=logging.INFO)\n",
+        "nest_asyncio.apply()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nH5-pXaZw5jg"
+      },
+      "source": [
+        "### Authenticate"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "SAnwvDofwhw1"
+      },
+      "outputs": [],
+      "source": [
+        "authentication_data = canopy.prompt_for_authentication()\n",
+        "session = canopy.Session(authentication_data)\n",
+        "session.authentication.authenticate()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tnJeZcc0vHif"
+      },
+      "source": [
+        "## Introduction: Config Management\n",
+        "\n",
+        "You can save and load configs at any level within the car model, allowing you to build up libraries of sub-compoenents. Each one of these sub-components can be named and have tags and notes applied to make them more searchable.\n",
+        "They can also be encrypted and saved, downloaded, exported, and catalogued via the API.\n",
+        "\n",
+        "Remember, everything you can do through the UI can be done through the API as well."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "og809ltWzgjP"
+      },
+      "source": [
+        "## Example 1: List all saved track configurations\n",
+        "\n",
+        "We're going to load all of the (non-default) saved track configurations and print a table of their name and their elevation above sea level"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 277
+        },
+        "id": "5j5YbZlUzfRx",
+        "outputId": "173c5a76-45c3-46c2-a37d-85733a1e4dda"
+      },
+      "outputs": [],
+      "source": [
+        "# We don't have a neat wrapper for this function, so we'll use the API directly\n",
+        "from typing import List\n",
+        "\n",
+        "config_api = canopy.openapi.ConfigApi(session.async_client)\n",
+        "\n",
+        "# Note that these are returned in order of oldest first\n",
+        "metadata_result: canopy.openapi.GetConfigsQueryResult = await config_api.config_get_configs(session.authentication.tenant_id, 'track')\n",
+        "\n",
+        "documents: List[canopy.openapi.CanopyDocument] = metadata_result.query_results.documents\n",
+        "if len(documents) == 0:\n",
+        "    raise canopy.NotFoundError('No config found matching the specified criteria.')\n",
+        "\n",
+        "async def load_track_from_document(document: canopy.openapi.CanopyDocument):\n",
+        "    tenant_id = session.authentication.tenant_id\n",
+        "    track = await canopy.load_config(session, document.document_id, tenant_id=tenant_id)\n",
+        "    logging.info(f'Loaded track: {track.raw_data['name']} ({track.config_id})')\n",
+        "    return track\n",
+        "\n",
+        "# I'm explicitly taking the last five elements here to get the most recent tracks\n",
+        "all_tracks = [await load_track_from_document(doc) for doc in documents[-6:-1]]\n",
+        "\n",
+        "\n",
+        "\n",
+        "# Build up a data table for the tracks that we've recorded\n",
+        "track_data_table = []\n",
+        "\n",
+        "for track in all_tracks:\n",
+        "    # I carefully call raw_data here. If we call data directly, it triggers lazy\n",
+        "    # conversion of the dictionary to a strongly typed object, is slower, and not necessary\n",
+        "    track_data_table.append({\n",
+        "        'Track Name': track.raw_data['name'],\n",
+        "        'Elevation': track.raw_data['hTrackAboveSeaLevel']\n",
+        "    })\n",
+        "\n",
+        "# Display the data table\n",
+        "import pandas as pd\n",
+        "df = pd.DataFrame(track_data_table)\n",
+        "print(df)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Example 2: Load all saved tyre configs\n",
+        "\n",
+        "We're going to load all of the configurations which have been saved under the `car.tyres.front` path. This requires adding a _sub_tree_path_."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# We don't have a neat wrapper for this function, so we'll use the API directly\n",
+        "from typing import List\n",
+        "\n",
+        "config_api = canopy.openapi.ConfigApi(session.async_client)\n",
+        "\n",
+        "sub_tree_path = 'tyres.front'\n",
+        "\n",
+        "# Note that these are returned in order of oldest first\n",
+        "metadata_result: canopy.openapi.GetConfigsQueryResult = await config_api.config_get_configs(session.authentication.tenant_id, 'car', **canopy.defined_kwargs(\n",
+        "            sub_tree_path=sub_tree_path))\n",
+        "\n",
+        "documents: List[canopy.openapi.CanopyDocument] = metadata_result.query_results.documents\n",
+        "if len(documents) == 0:\n",
+        "    raise canopy.NotFoundError('No config found matching the specified criteria.')\n",
+        "\n",
+        "# The documents list is now a list of all of the configs that have been saved at that specific sub_tree_path.\n",
+        "# This might be enough for your needs, but if you want to load the objects themselves, you need to do that explicitly:\n",
+        "\n",
+        "async def load_sub_tree_config(document: canopy.openapi.CanopyDocument, sub_tree_path: str):\n",
+        "    tenant_id = session.authentication.tenant_id\n",
+        "    # You MUST specify the sub_tree_path here again when loading, otherwise you get an invalid ID\n",
+        "    config = await canopy.load_config(session, document.document_id, tenant_id=tenant_id, sub_tree_path=sub_tree_path)\n",
+        "    logging.info(f'Loaded car sub-tree config: {config.config_id}')\n",
+        "    return config\n",
+        "\n",
+        "# All tyres\n",
+        "all_tyres = [await load_sub_tree_config(doc, sub_tree_path) for doc in documents[-6:-1]]\n",
+        "\n",
+        "# For each tyre, let's find out the grip factor\n",
+        "tyre_data_table = []\n",
+        "for tyre_config in all_tyres:\n",
+        "    tyre_data_table.append({\n",
+        "        'Tyre ID': tyre_config.config_id,\n",
+        "        'Path': tyre_config.raw_data['path'],\n",
+        "        'Grip Factor': tyre_config.raw_data['definition']['rGripFactor']\n",
+        "    })\n",
+        "\n",
+        "# Display the data table\n",
+        "import pandas as pd\n",
+        "df = pd.DataFrame(tyre_data_table)\n",
+        "print(df)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Example 3: Search metadata and custom properties using a filter\n",
+        "\n",
+        "Canopy enables you to set custom properties on top-level configs. They can be used in a filter to select specific configurations.\n",
+        "However, note that filtering to custom properties is only available on top-level configs and cannot be used with a sub-tree path in this way."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# We don't have a neat wrapper for this function, so we'll use the API directly\n",
+        "from typing import List\n",
+        "\n",
+        "config_api = canopy.openapi.ConfigApi(session.async_client)\n",
+        "\n",
+        "sub_tree_path = 'tyres.front'\n",
+        "\n",
+        "filter = canopy.create_list_filter(\n",
+        "    session,\n",
+        "    is_study=False,\n",
+        "    custom_properties={'Repo':'python-examples'}\n",
+        "    )\n",
+        "\n",
+        "# Note that these are returned in order of oldest first\n",
+        "metadata_result: canopy.openapi.GetConfigsQueryResult = await config_api.config_get_configs(session.authentication.tenant_id, 'car', **canopy.defined_kwargs(\n",
+        "            filter=filter.serialize()\n",
+        "            ))\n",
+        "\n",
+        "documents: List[canopy.openapi.CanopyDocument] = metadata_result.query_results.documents\n",
+        "if len(documents) == 0:\n",
+        "    raise canopy.NotFoundError('No config found matching the specified criteria.')\n",
+        "\n",
+        "# We can load the config and check that it has the custom property\n",
+        "document = documents[-1]\n",
+        "config = await canopy.load_config(session, document.document_id, tenant_id=session.authentication.tenant_id)\n",
+        "print(f'Loaded config: {config.config_id} with Repo={document.properties[\"Repo\"]}')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Example 4: Searching for a specific value in the config data\n",
+        "\n",
+        "On the platform, you can search for configs which have a specific value, e.g. chassis models with a running mass of < 3000 kg.\n",
+        "We can do this too through the API by manually creating our own list filter instead of using the `create_list_filter` helper.\n",
+        "\n",
+        "This is about as direct as we can get into calling directly into the API"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "config_api = canopy.openapi.ConfigApi(session.async_client)\n",
+        "\n",
+        "# Find chassis configs which meet the criteria\n",
+        "sub_tree_path = 'chassis'\n",
+        "\n",
+        "conditions: List[canopy.openapi.ListFilterCondition] = [\n",
+        "    canopy.openapi.ListFilterCondition(\n",
+        "            source='config',\n",
+        "            name='carRunningMass.mCar',\n",
+        "            operator='greaterThan',\n",
+        "            value=3000\n",
+        "        )\n",
+        "]\n",
+        "\n",
+        "group = canopy.openapi.ListFilterGroup(\n",
+        "        operator='and',\n",
+        "        conditions=conditions)\n",
+        "\n",
+        "filter = canopy.SerializableValue(\n",
+        "        session,\n",
+        "        canopy.openapi.ListFilter(\n",
+        "            items_per_page=0,\n",
+        "            order_by_property='modifiedDate',\n",
+        "            order_by_descending=False,\n",
+        "            query=group)\n",
+        "        )\n",
+        "\n",
+        "metadata_result: canopy.openapi.GetConfigsQueryResult = await config_api.config_get_configs(\n",
+        "    session.authentication.tenant_id,\n",
+        "    'car',\n",
+        "    **canopy.defined_kwargs(\n",
+        "        filter=filter.serialize(),\n",
+        "        sub_tree_path=sub_tree_path))\n",
+        "\n",
+        "documents: List[canopy.openapi.CanopyDocument] = metadata_result.query_results.documents\n",
+        "if len(documents) == 0:\n",
+        "    raise canopy.NotFoundError('No config found matching the specified criteria.')\n",
+        "\n",
+        "# Print out the masses of the matching chassis configs\n",
+        "for document in documents:\n",
+        "    config = await canopy.load_config(session, document.document_id, tenant_id=session.authentication.tenant_id, sub_tree_path=sub_tree_path)\n",
+        "    mass = config.raw_data['definition']['carRunningMass']['mCar']\n",
+        "    print(f'Chassis Config ID: {config.config_id}, Mass: {mass} kg')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Example 5: Searching in a worksheet\n",
+        "\n",
+        "Canopy configs can be moved into worksheets, which takes them out of the normal list of configs to simplify searching and minimise scrolling of configurations. We generally recommend running studies through worksheets.\n",
+        "\n",
+        "In order to search in a worksheet, you need to know the name or the ID of the worksheet. We'll use a prompt to get either the name or id of the worksheet, but you may optionally choose to hard-code this."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Load the Worksheet\n",
+        "\n",
+        "See also \"loading_worksheet_study_data\"."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import re\n",
+        "\n",
+        "worksheet_name_or_id = input(\"Worksheet name or ID: \")\n",
+        "\n",
+        "worksheet_id = None\n",
+        "if re.match('^[0-9a-f]{32}$', worksheet_name_or_id):\n",
+        "    worksheet_id = worksheet_name_or_id\n",
+        "else:\n",
+        "    worksheet_name = worksheet_name_or_id\n",
+        "    worksheet = await canopy.find_config(session, 'worksheet', worksheet_name)\n",
+        "    worksheet_id = worksheet.config_id\n",
+        "\n",
+        "logging.info(f'Using worksheet ID: {worksheet_id}')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Search in the worksheet for a car configuration\n",
+        "\n",
+        "We want to retrieve all of the cars in the worksheet, so we need to use our direct API calls."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# We don't have a neat wrapper for this function, so we'll use the API directly\n",
+        "from typing import List\n",
+        "\n",
+        "config_api = canopy.openapi.ConfigApi(session.async_client)\n",
+        "\n",
+        "# Define a filter which includes the parent_worksheet_id\n",
+        "filter_ = canopy.create_list_filter(\n",
+        "    session,\n",
+        "    is_study=False,\n",
+        "    parent_worksheet_id=worksheet_id,\n",
+        "    )\n",
+        "\n",
+        "# Note that these are returned in order of oldest first\n",
+        "metadata_result: canopy.openapi.GetConfigsQueryResult = await config_api.config_get_configs(session.authentication.tenant_id, 'car',\n",
+        "        **canopy.defined_kwargs(\n",
+        "            filter=filter_.serialize()))\n",
+        "\n",
+        "documents: List[canopy.openapi.CanopyDocument] = metadata_result.query_results.documents\n",
+        "if len(documents) == 0:\n",
+        "    raise canopy.NotFoundError('No config found matching the specified criteria.')\n",
+        "\n",
+        "async def load_car_from_document(document: canopy.openapi.CanopyDocument):\n",
+        "    tenant_id = session.authentication.tenant_id\n",
+        "    car = await canopy.load_config(session, document.document_id, tenant_id=tenant_id)\n",
+        "    logging.info(f'Loaded car: {car.document.name} ({car.config_id})')\n",
+        "    return car\n",
+        "\n",
+        "# I'm explicitly taking the last five elements here to get the most recent cars\n",
+        "all_cars = [await load_car_from_document(doc) for doc in documents]\n",
+        "\n",
+        "# Now you can do what you like with the loaded cars"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "include_colab_link": true,
+      "name": "loading_and_saving_configs.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/loading_saved_components.ipynb
+++ b/loading_saved_components.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/CanopySimulations/canopy-python-examples/blob/master/loading_and_saving_configs.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/CanopySimulations/canopy-python-examples/blob/master/loading_saved_components.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "source": [
         "## Introduction: Config Management\n",
         "\n",
-        "You can save and load configs at any level within the car model, allowing you to build up libraries of sub-compoenents. Each one of these sub-components can be named and have tags and notes applied to make them more searchable.\n",
+        "You can save and load configs at any level within the car model, allowing you to build up libraries of sub-components. Each one of these sub-components can be named and have tags and notes applied to make them more searchable.\n",
         "They can also be encrypted and saved, downloaded, exported, and catalogued via the API.\n",
         "\n",
         "Remember, everything you can do through the UI can be done through the API as well."
@@ -155,7 +155,7 @@
         "    return track\n",
         "\n",
         "# I'm explicitly taking the last five elements here to get the most recent tracks\n",
-        "all_tracks = [await load_track_from_document(doc) for doc in documents[-6:-1]]\n",
+        "all_tracks = [await load_track_from_document(doc) for doc in documents[-5:]]\n",
         "\n",
         "\n",
         "\n",
@@ -216,8 +216,8 @@
         "    logging.info(f'Loaded car sub-tree config: {config.config_id}')\n",
         "    return config\n",
         "\n",
-        "# All tyres\n",
-        "all_tyres = [await load_sub_tree_config(doc, sub_tree_path) for doc in documents[-6:-1]]\n",
+        "# Just the last five tyres for demonstration purposes\n",
+        "all_tyres = [await load_sub_tree_config(doc, sub_tree_path) for doc in documents[-5:]]\n",
         "\n",
         "# For each tyre, let's find out the grip factor\n",
         "tyre_data_table = []\n",
@@ -255,8 +255,6 @@
         "\n",
         "config_api = canopy.openapi.ConfigApi(session.async_client)\n",
         "\n",
-        "sub_tree_path = 'tyres.front'\n",
-        "\n",
         "filter = canopy.create_list_filter(\n",
         "    session,\n",
         "    is_study=False,\n",
@@ -284,7 +282,7 @@
       "source": [
         "## Example 4: Searching for a specific value in the config data\n",
         "\n",
-        "On the platform, you can search for configs which have a specific value, e.g. chassis models with a running mass of < 3000 kg.\n",
+        "On the platform, you can search for configs which have a specific value, e.g. chassis models with a running mass of > 3000 kg.\n",
         "We can do this too through the API by manually creating our own list filter instead of using the `create_list_filter` helper.\n",
         "\n",
         "This is about as direct as we can get into calling directly into the API"
@@ -403,7 +401,7 @@
         "config_api = canopy.openapi.ConfigApi(session.async_client)\n",
         "\n",
         "# Define a filter which includes the parent_worksheet_id\n",
-        "filter_ = canopy.create_list_filter(\n",
+        "filter = canopy.create_list_filter(\n",
         "    session,\n",
         "    is_study=False,\n",
         "    parent_worksheet_id=worksheet_id,\n",
@@ -412,7 +410,7 @@
         "# Note that these are returned in order of oldest first\n",
         "metadata_result: canopy.openapi.GetConfigsQueryResult = await config_api.config_get_configs(session.authentication.tenant_id, 'car',\n",
         "        **canopy.defined_kwargs(\n",
-        "            filter=filter_.serialize()))\n",
+        "            filter=filter.serialize()))\n",
         "\n",
         "documents: List[canopy.openapi.CanopyDocument] = metadata_result.query_results.documents\n",
         "if len(documents) == 0:\n",
@@ -424,7 +422,6 @@
         "    logging.info(f'Loaded car: {car.document.name} ({car.config_id})')\n",
         "    return car\n",
         "\n",
-        "# I'm explicitly taking the last five elements here to get the most recent cars\n",
         "all_cars = [await load_car_from_document(doc) for doc in documents]\n",
         "\n",
         "# Now you can do what you like with the loaded cars"
@@ -434,7 +431,7 @@
   "metadata": {
     "colab": {
       "include_colab_link": true,
-      "name": "loading_and_saving_configs.ipynb",
+      "name": "loading_saved_components.ipynb",
       "provenance": []
     },
     "kernelspec": {


### PR DESCRIPTION
This new ipynb notebook documents and provides samples of the process of using the API to filter and load configurations that have been saved onto the platform.

Examples are included for:
- Listing all saved configurations of a specific type
- Loading all saved configurations stored at a sub-tree path
- Searching configurations based on metadata and a custom filter
- Searching for a specific car vlaue in the config data (without loading the full car)
- Loading configurations from a worksheet.

Each of these examples demonstrates increasingly complex functionality and more operations in the direct API. Although some helper functions are used, predominantly this is using direct calls to the `canopy.openapi` module.